### PR TITLE
change firebase to point to SoSA account instead of EmLem's

### DIFF
--- a/src/services/firebase.js
+++ b/src/services/firebase.js
@@ -1,12 +1,12 @@
 import firebase from 'firebase'
 
 var config = {
-  apiKey: 'AIzaSyC14hJ31aB7YF_0_yOZ_3KG1sPmKlEtLh0',
-  authDomain: 'glean-tennessee.firebaseapp.com',
-  databaseURL: 'https://glean-tennessee.firebaseio.com',
-  projectId: 'glean-tennessee',
-  storageBucket: 'glean-tennessee.appspot.com',
-  messagingSenderId: '272130733451'
+  apiKey: 'AIzaSyAd39Tc5YR1OJMeZbqG8PjzD2DE6sYY0N8',
+  authDomain: 'gleantn-1794b.firebaseapp.com',
+  databaseURL: 'https://gleantn-1794b.firebaseio.com',
+  projectId: 'gleantn-1794b',
+  storageBucket: 'gleantn-1794b.appspot.com',
+  messagingSenderId: '431241114929'
 }
 
 firebase.initializeApp(config)
@@ -57,7 +57,7 @@ const FirebaseService = () => {
     new Promise((resolve, reject) => {
       firebase
         .database()
-        .ref('users/' + data.uid)
+        .ref('farmers/' + data.uid)
         .update(data, error => {
           if (error) {
             reject(error)
@@ -70,7 +70,7 @@ const FirebaseService = () => {
   const getUserProfile = () =>
     firebase
       .database()
-      .ref('/users/' + firebase.auth().currentUser.uid)
+      .ref('/farmers/' + firebase.auth().currentUser.uid)
       .once('value')
 
   return {


### PR DESCRIPTION
Simply changing config object to point the firebase at the SoSA google/firebase account instead of my own. I think this will be best for project sustainability (plus the iOS app is pointed at the same firebase account, should we get somewhere that we want to use that).
Volunteers can see leadership for access to SoSA google account.

I also changed 'users' to 'farmers' because that is the collection currently set up on the (probably ne'er to be touched again?) iOS and android apps as well as the earlier version of the web app.
I am open to discussion about changing the collection titles, but I think volunteer gleaners may belong in their own collection and farmers (donors?) maybe be separate.

To test, make sure you can still register and sign in using this firebase config info.