### PR TITLE
Issue44: Landing Page: Set default to Dashboard

### DIFF
--- a/src/navigation/routes.js
+++ b/src/navigation/routes.js
@@ -9,8 +9,8 @@ const routes = {
   success: [
     {
       path: '/',
-      action: ({params}) => <Home params={params} />,
-      protected: false
+      action: ({params}) => <Dashboard params={params} />,
+      protected: true
     },
     {
       path: '/signup',


### PR DESCRIPTION
This should set the default behaviors for / as follows:

Logged in: Dashboard (submit glean request screen)
Logged out: Login (Log in form)

If accepted, this will also make the Home screen superfluous.

[Issue 44]