### PR TITLE
removed ignored callbacks from DOM per React console error

### DIFF
--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -16,14 +16,12 @@ class Navigation extends Component {
       href="/login"
       children={'Log In'}
       key="login"
-      callBack={this.closeMenu}
     />,
     <Link
       key="register"
       className="nav-item nav-link"
       href="/signup"
       children={'Register'}
-      callBack={this.closeMenu}
     />
   ]
 
@@ -33,21 +31,18 @@ class Navigation extends Component {
       href="/dashboard"
       children={'Gleaning Request'}
       key="request"
-      callBack={this.closeMenu}
     />,
     <Link
       className="nav-item nav-link"
       href="/profile"
       children={'Profile'}
       key="profile"
-      callBack={this.closeMenu}
     />,
     <Link
       className="nav-item nav-link"
       onClick={api.logout}
       children={'Log Out'}
       key="logout"
-      callBack={this.closeMenu}
     />
   ]
 


### PR DESCRIPTION
@CoreyAR and @Rian501 - I believe this will resolve #77.

I noticed React was giving an error:
> React does not recognize the `callBack` prop on a DOM element.

So, I removed all of them. the signup page seemed to work fine then, and I saw that the firebase function fired (via some `console.log`s I temporarily added).

Would one of you be willing to test it too? Thanks!