### PR TITLE
Fix dom prop warning

### DIFF
--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -16,7 +16,7 @@ class Link extends React.Component {
   }
 
   render() {
-    const { children, className, ...rest } = this.props
+    const {children, className, ...rest} = this.props
     const active = this.props.href === window.location.pathname ? 'active' : ''
     delete rest.callBack // Don't pass internal props to the DOM
     return (

--- a/src/components/link/index.js
+++ b/src/components/link/index.js
@@ -16,12 +16,13 @@ class Link extends React.Component {
   }
 
   render() {
-    const {children, className} = this.props
+    const { children, className, ...rest } = this.props
     const active = this.props.href === window.location.pathname ? 'active' : ''
+    delete rest.callBack // Don't pass internal props to the DOM
     return (
       <a
         onClick={this.transition}
-        {...this.props}
+        {...rest}
         className={classnames(className, active)}
       >
         {children}


### PR DESCRIPTION
Deletes the internal `callBack` prop in the `Link` component because it produces warnings that it shouldn't be spread to the DOM.

This props is only used internally by the component.